### PR TITLE
after_save does not guarantee that the DB is in a permanent state

### DIFF
--- a/lib/delayed/paperclip.rb
+++ b/lib/delayed/paperclip.rb
@@ -53,7 +53,7 @@ module Delayed
         self.send("before_#{name}_post_process", :"halt_processing_for_#{name}")
 
         before_save :"#{name}_processing!"
-        after_save  :"enqueue_job_for_#{name}"
+        after_commit :"enqueue_job_for_#{name}"
       end
     end
 

--- a/lib/delayed/paperclip.rb
+++ b/lib/delayed/paperclip.rb
@@ -53,7 +53,11 @@ module Delayed
         self.send("before_#{name}_post_process", :"halt_processing_for_#{name}")
 
         before_save :"#{name}_processing!"
-        after_commit :"enqueue_job_for_#{name}"
+        if respond_to? :after_commit
+          after_commit :"enqueue_job_for_#{name}"
+        else
+          after_save :"enqueue_job_for_#{name}"
+        end
       end
     end
 


### PR DESCRIPTION
This is relevant to issue #22

We currently trigger the background task as such: 

``` ruby
after_save  :"enqueue_job_for_#{name}"
```

At this point (when creating a record) there is nothing in the DB according to processes using a different connection (default mysql setting). only after the commit we should trigger the task.

``` ruby
after_commit  :"enqueue_job_for_#{name}"
```

See: http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html
