### PR TITLE
default_url and fake image service

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -1,6 +1,7 @@
 require 'paperclip'
 
 require 'delayed_paperclip'
+require 'delayed_paperclip/paperclip'
 require 'delayed_paperclip/jobs/delayed_job'
 require 'delayed_paperclip/jobs/resque'
 

--- a/lib/delayed_paperclip/paperclip.rb
+++ b/lib/delayed_paperclip/paperclip.rb
@@ -1,0 +1,21 @@
+module Paperclip
+  
+  class Attachment
+    
+    def url(style_name = default_style, use_timestamp = @use_timestamp)
+      default_url = @default_url.is_a?(Proc) ? @default_url.call(self) : @default_url
+      url = exists?(style_name) ? interpolate(@url, style_name) : interpolate(default_url, style_name)
+      use_timestamp && updated_at ? [url, updated_at].compact.join(url.include?("?") ? "&" : "?") : url
+    end
+    
+  end
+  
+  module Interpolations
+
+    def size(attachment, style_name)
+      return attachment.styles[style_name].geometry.to_s.gsub(/[^0-9x]/, '\\1').gsub(/^[x]+|[x]+$/, '')
+    end
+    
+  end
+  
+end


### PR DESCRIPTION
when an attachment is not generated yet, paperclip use normal url
in fact paperclip use "original_filename" to choose between "url" and "default_url" ; if "original_filename" is not null and resque don't unqueue yet there is a 404 error on image request

so I overrode a method in Paperclip::Attachment

```
module Paperclip

  class Attachment

    def url(style_name = default_style, use_timestamp = @use_timestamp)
      default_url = @default_url.is_a?(Proc) ? @default_url.call(self) : @default_url
      # paperclip original line : url = original_filename.nil? ? interpolate(default_url, style_name) : interpolate(@url, style_name)
      url = exists?(style_name) ? interpolate(@url, style_name) : interpolate(default_url, style_name)
      use_timestamp && updated_at ? [url, updated_at].compact.join(url.include?("?") ? "&" : "?") : url
    end

  end

end
```

to make easier default_url management I had a new interpolation in Paperclip url generation which return size for fake image services like dummyimage.com

```
module Paperclip

  module Interpolations

    def size(attachment, style_name)
      return attachment.styles[style_name].geometry.to_s.gsub(/[^0-9x]/, '\\1').gsub(/^[x]+|[x]+$/, '')
    end

  end

end
```
