### PR TITLE
Preventing an endless loop when using model callbacks.

### DIFF
--- a/lib/delayed_paperclip.rb
+++ b/lib/delayed_paperclip.rb
@@ -157,7 +157,15 @@ module Paperclip
 
     def post_process_styles_with_processing(*args)
       post_process_styles_without_processing(*args)
-      instance.update_attribute("#{name}_processing", false) if instance.respond_to?(:"#{name}_processing?")
+      
+      # update_column is available in rails 3.1 instead we can do this to update the attribute without callbacks
+
+      #instance.update_column("#{name}_processing", false) if instance.respond_to?(:"#{name}_processing?")
+      if instance.respond_to?(:"#{name}_processing?")
+        instance.send("#{name}_processing=", false)
+        instance.class.update_all({ "#{name}_processing" => false }, instance.class.primary_key => instance.id)
+      end
+      
     end
     alias_method_chain :post_process_styles, :processing
 

--- a/test/base_delayed_paperclip_test.rb
+++ b/test/base_delayed_paperclip_test.rb
@@ -127,4 +127,13 @@ module BaseDelayedPaperclipTest
     dummy.save!
     process_jobs
   end
+  
+  def test_delayed_paperclip_functioning_with_after_update_callback
+    reset_class "Dummy", :with_processed => true, :with_after_update_callback => true
+    Dummy.any_instance.expects(:reprocess)
+    dummy = Dummy.new(:image => File.open("#{ROOT}/test/fixtures/12k.png"))
+    dummy.save!
+    process_jobs
+    dummy.update_attributes(:name => "hi")
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ end
 
 def build_dummy_table(with_processed)
   ActiveRecord::Base.connection.create_table :dummies, :force => true do |t|
+    t.string   :name
     t.string   :image_file_name
     t.string   :image_content_type
     t.integer  :image_file_size
@@ -55,6 +56,11 @@ def reset_class(class_name, options)
     include Paperclip::Glue
     has_attached_file     :image
     process_in_background :image, options if options[:with_processed]
+    after_update :reprocess if options[:with_after_update_callback]
+    
+    def reprocess
+      image.reprocess!
+    end
   end
   klass.reset_column_information
   klass


### PR DESCRIPTION
As requested ... here is the pull request.

update_attribute performs rails callbacks which can create an endless loop when saving if you have callbacks defined in your model.
