### PR TITLE
delayed paperclip broken under paperclip 2.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "paperclip", '2.4.5'
+gem "paperclip", '2.5.0'
 
 gem "appraisal"
 gem "mocha"

--- a/lib/delayed_paperclip/attachment.rb
+++ b/lib/delayed_paperclip/attachment.rb
@@ -7,7 +7,7 @@ module DelayedPaperclip
       base.alias_method_chain :post_processing, :delay
       base.alias_method_chain :post_processing=, :delay
       base.alias_method_chain :save, :prepare_enqueueing
-      base.alias_method_chain :most_appropriate_url, :processed
+      base.alias_method_chain :url, :processed
       base.alias_method_chain :post_process_styles, :processing
     end
 
@@ -64,7 +64,7 @@ module DelayedPaperclip
         end
       end
 
-      def most_appropriate_url_with_processed
+      def url_with_processed
         if original_filename.nil? || delayed_default_url?
           default_url
         else


### PR DESCRIPTION
the 'most_appropriate_url' has being removed from the attachment and now we are back using simple 'url' calls and that calls most_appropriate_url from url_generator.

Regards,
Marco Aguilar
